### PR TITLE
Add macOS and Linux support for finding and reusing Cursor workspace instances

### DIFF
--- a/Editor/ProcessRunner.cs
+++ b/Editor/ProcessRunner.cs
@@ -125,7 +125,17 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			{
 				var workspaces = new List<string>();
 				var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-				var cursorStoragePath = Path.Combine(userProfile, "AppData", "Roaming", "cursor", "User", "workspaceStorage");
+				string cursorStoragePath;
+
+#if UNITY_EDITOR_OSX
+				cursorStoragePath = Path.Combine(userProfile, "Library", "Application Support", "cursor", "User", "workspaceStorage");
+#elif UNITY_EDITOR_LINUX
+				cursorStoragePath = Path.Combine(userProfile, ".config", "cursor", "User", "workspaceStorage");
+#else
+				cursorStoragePath = Path.Combine(userProfile, "AppData", "Roaming", "cursor", "User", "workspaceStorage");
+#endif
+				
+				Debug.Log($"[Cursor] Looking for workspaces in: {cursorStoragePath}");
 				
 				if (Directory.Exists(cursorStoragePath))
 				{
@@ -185,6 +195,10 @@ namespace Microsoft.Unity.VisualStudio.Editor
 							continue;
 						}
 					}
+				}
+				else
+				{
+					Debug.LogWarning($"[Cursor] Workspace storage directory not found: {cursorStoragePath}");
 				}
 
 				return workspaces.Distinct().ToArray();

--- a/Editor/ProcessRunner.cs
+++ b/Editor/ProcessRunner.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 #if UNITY_EDITOR_OSX
 				cursorStoragePath = Path.Combine(userProfile, "Library", "Application Support", "cursor", "User", "workspaceStorage");
 #elif UNITY_EDITOR_LINUX
-				cursorStoragePath = Path.Combine(userProfile, ".config", "cursor", "User", "workspaceStorage");
+				cursorStoragePath = Path.Combine(userProfile, ".config", "Cursor", "User", "workspaceStorage");
 #else
 				cursorStoragePath = Path.Combine(userProfile, "AppData", "Roaming", "cursor", "User", "workspaceStorage");
 #endif


### PR DESCRIPTION
## Description
This PR extends the existing Cursor instance detection functionality to support macOS and Linux platforms, while maintaining compatibility with Windows. The main changes include:

1. Added platform-specific process name detection for new platforms:
   - macOS: "Cursor" and "Cursor Helper"
   - Linux: "cursor" and "Cursor"
   - Windows: Maintains existing "cursor" process detection

2. Implemented platform-specific workspace path handling:
   - macOS/Linux: Ensures paths start with "/" for consistent comparison
   - Windows: Preserves existing drive letter format (e.g., "c:/users/...")

3. Enhanced path normalization and comparison:
   - Standardizes path separators to forward slashes
   - Handles case-insensitive path comparison

## Testing
The changes have been tested on:
- macOS 15.4.1
- Ubuntu 25.04
- Windows (verified compatibility with existing functionality)

## Additional Notes
- Added debug logging to help track workspace matching
- Improved error handling for process workspace detection
- Maintains backward compatibility with existing Windows functionality

## Related Issue
https://github.com/boxqkrtm/com.unity.ide.cursor/issues/13