### PR TITLE
[fix] SdkStyleProjectGeneration missing utf-8 xml header

### DIFF
--- a/Editor/ProjectGeneration/SdkStyleProjectGeneration.cs
+++ b/Editor/ProjectGeneration/SdkStyleProjectGeneration.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 		{
 			headerBuilder = new StringBuilder();
 
+			headerBuilder.Append(@"<?xml version=""1.0"" encoding=""utf-8""?>").Append(k_WindowsNewline);
 			headerBuilder.Append(@"<Project ToolsVersion=""Current"">").Append(k_WindowsNewline);
 			headerBuilder.Append(@"  <!-- Generated file, do not modify, your changes will be overwritten (use AssetPostprocessor.OnGeneratedCSProject) -->").Append(k_WindowsNewline);
 


### PR DESCRIPTION
In a project, I used CursorEditor and a plugin that also affects the generation result of the .csproj project file. Since the project file generated by SdkStyleProjectGeneration does not specify a UTF-8 encoded XML header, when another plugin generates an XML file based on the XmlDoc API, it will automatically write a UTF-16 encoded XML header, causing the problem that the project cannot be normally opened by Cursor. Cursor will print the error log like "There is no Unicode byte order mark. Cannot switch to Unicode."

![image](https://github.com/user-attachments/assets/6c6a94da-de7d-4946-8a49-520ccc8c4f9f)
![image](https://github.com/user-attachments/assets/14851052-3e14-4180-9380-73246fb5fc24)
![image](https://github.com/user-attachments/assets/5e876de2-d792-4a4d-b76c-99fd4ad4a100)

