### PR TITLE
refactor: migrate from Cursor to Antigravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Code Editor Package for Cursor
+# Code Editor Package for Antigravity
 
 ## [2.0.27] - 2025-11-02
 
 Integration:
 
-- Add Multiple or Single Cursor Instance Options
+- Add Multiple or Single Antigravity Instance Options
 
 ## [2.0.26] - 2025-11-02
 

--- a/Editor/Discovery.cs
+++ b/Editor/Discovery.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 	{
 		public static IEnumerable<IVisualStudioInstallation> GetVisualStudioInstallations()
 		{
-			foreach (var installation in VisualStudioCursorInstallation.GetVisualStudioInstallations())
+			foreach (var installation in VisualStudioAntigravityInstallation.GetVisualStudioInstallations())
 				yield return installation;
 			foreach (var installation in VisualStudioCodiumInstallation.GetVisualStudioInstallations())
 				yield return installation;
@@ -23,7 +23,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 		{
 			try
 			{
-				if (VisualStudioCursorInstallation.TryDiscoverInstallation(editorPath, out installation))
+				if (VisualStudioAntigravityInstallation.TryDiscoverInstallation(editorPath, out installation))
 					return true;
 				if (VisualStudioCodiumInstallation.TryDiscoverInstallation(editorPath, out installation))
 					return true;
@@ -38,7 +38,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 
 		public static void Initialize()
 		{
-            VisualStudioCursorInstallation.Initialize();
+            VisualStudioAntigravityInstallation.Initialize();
             VisualStudioCodiumInstallation.Initialize();
 		}
 	}

--- a/Editor/ProcessRunner.cs
+++ b/Editor/ProcessRunner.cs
@@ -125,19 +125,19 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			{
 				var workspaces = new List<string>();
 				var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-				string cursorStoragePath;
+				string antigravityStoragePath;
 
 #if UNITY_EDITOR_OSX
-				cursorStoragePath = Path.Combine(userProfile, "Library", "Application Support", "cursor", "User", "workspaceStorage");
+				antigravityStoragePath = Path.Combine(userProfile, "Library", "Application Support", "antigravity", "User", "workspaceStorage");
 #elif UNITY_EDITOR_LINUX
-				cursorStoragePath = Path.Combine(userProfile, ".config", "Cursor", "User", "workspaceStorage");
+				antigravityStoragePath = Path.Combine(userProfile, ".config", "Antigravity", "User", "workspaceStorage");
 #else
-				cursorStoragePath = Path.Combine(userProfile, "AppData", "Roaming", "cursor", "User", "workspaceStorage");
+				antigravityStoragePath = Path.Combine(userProfile, "AppData", "Roaming", "antigravity", "User", "workspaceStorage");
 #endif
-				
-				if (Directory.Exists(cursorStoragePath))
+
+				if (Directory.Exists(antigravityStoragePath))
 				{
-					foreach (var workspaceDir in Directory.GetDirectories(cursorStoragePath))
+					foreach (var workspaceDir in Directory.GetDirectories(antigravityStoragePath))
 					{
 						try
 						{
@@ -189,21 +189,21 @@ namespace Microsoft.Unity.VisualStudio.Editor
 						}
 						catch (Exception ex)
 						{
-							Debug.LogWarning($"[Cursor] Error reading workspace state file: {ex.Message}");
+							Debug.LogWarning($"[Antigravity] Error reading workspace state file: {ex.Message}");
 							continue;
 						}
 					}
 				}
 				else
 				{
-					Debug.LogWarning($"[Cursor] Workspace storage directory not found: {cursorStoragePath}");
+					Debug.LogWarning($"[Antigravity] Workspace storage directory not found: {antigravityStoragePath}");
 				}
 
 				return workspaces.Distinct().ToArray();
 			}
 			catch (Exception ex)
 			{
-				Debug.LogError($"[Cursor] Error getting workspace directory: {ex.Message}");
+				Debug.LogError($"[Antigravity] Error getting workspace directory: {ex.Message}");
 				return null;
 			}
 		}

--- a/Editor/VisualStudioAntigravityInstallation.cs
+++ b/Editor/VisualStudioAntigravityInstallation.cs
@@ -17,10 +17,10 @@ using Debug = UnityEngine.Debug;
 
 namespace Microsoft.Unity.VisualStudio.Editor
 {
-	internal class VisualStudioCursorInstallation : VisualStudioInstallation
+	internal class VisualStudioAntigravityInstallation : VisualStudioInstallation
 	{
 		private static readonly IGenerator _generator = new SdkStyleProjectGeneration();
-		internal const string ReuseExistingWindowKey = "cursor_reuse_existing_window";
+		internal const string ReuseExistingWindowKey = "antigravity_reuse_existing_window";
 
 		public override bool SupportsAnalyzers
 		{
@@ -71,11 +71,11 @@ namespace Microsoft.Unity.VisualStudio.Editor
 		private static bool IsCandidateForDiscovery(string path)
 		{
 #if UNITY_EDITOR_OSX
-			return Directory.Exists(path) && Regex.IsMatch(path, ".*Cursor.*.app$", RegexOptions.IgnoreCase);
+			return Directory.Exists(path) && Regex.IsMatch(path, ".*Antigravity.*.app$", RegexOptions.IgnoreCase);
 #elif UNITY_EDITOR_WIN
-			return File.Exists(path) && Regex.IsMatch(path, ".*Cursor.*.exe$", RegexOptions.IgnoreCase);
+			return File.Exists(path) && Regex.IsMatch(path, ".*Antigravity.*.exe$", RegexOptions.IgnoreCase);
 #else
-			return File.Exists(path) && path.EndsWith("cursor", StringComparison.OrdinalIgnoreCase);
+			return File.Exists(path) && path.EndsWith("antigravity", StringComparison.OrdinalIgnoreCase);
 #endif
 		}
 
@@ -133,10 +133,10 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			}
 
 			isPrerelease = isPrerelease || editorPath.ToLower().Contains("insider");
-			installation = new VisualStudioCursorInstallation()
+			installation = new VisualStudioAntigravityInstallation()
 			{
 				IsPrerelease = isPrerelease,
-				Name = "Cursor" + (isPrerelease ? " - Insider" : string.Empty) + (version != null ? $" [{version.ToString(3)}]" : string.Empty),
+				Name = "Antigravity" + (isPrerelease ? " - Insider" : string.Empty) + (version != null ? $" [{version.ToString(3)}]" : string.Empty),
 				Path = editorPath,
 				Version = version ?? new Version()
 			};
@@ -153,16 +153,16 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			var programFiles = IOPath.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
 
 			foreach (var basePath in new[] { localAppPath, programFiles }) {
-				candidates.Add(IOPath.Combine(basePath, "cursor", "cursor.exe"));
+				candidates.Add(IOPath.Combine(basePath, "antigravity", "antigravity.exe"));
 			}
 #elif UNITY_EDITOR_OSX
 			var appPath = IOPath.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
-			candidates.AddRange(Directory.EnumerateDirectories(appPath, "Cursor*.app"));
+			candidates.AddRange(Directory.EnumerateDirectories(appPath, "Antigravity*.app"));
 #elif UNITY_EDITOR_LINUX
 			// Well known locations
-			candidates.Add("/usr/bin/cursor");
-			candidates.Add("/bin/cursor");
-			candidates.Add("/usr/local/bin/cursor");
+			candidates.Add("/usr/bin/antigravity");
+			candidates.Add("/bin/antigravity");
+			candidates.Add("/usr/local/bin/antigravity");
 
 			// Preference ordered base directories relative to which desktop files should be searched
 			candidates.AddRange(GetXdgCandidates());
@@ -500,7 +500,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			}
 		}
 
-		private Process FindRunningCursorWithSolution(string solutionPath)
+		private Process FindRunningAntigravityWithSolution(string solutionPath)
 		{
 			var normalizedTargetPath = solutionPath.Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
 
@@ -518,13 +518,13 @@ namespace Microsoft.Unity.VisualStudio.Editor
 
 			// Get process name list based on different operating systems
 #if UNITY_EDITOR_OSX
-			processes.AddRange(Process.GetProcessesByName("Cursor"));
-			processes.AddRange(Process.GetProcessesByName("Cursor Helper"));
+			processes.AddRange(Process.GetProcessesByName("Antigravity"));
+			processes.AddRange(Process.GetProcessesByName("Antigravity Helper"));
 #elif UNITY_EDITOR_LINUX
-			processes.AddRange(Process.GetProcessesByName("cursor"));
-			processes.AddRange(Process.GetProcessesByName("Cursor"));
+			processes.AddRange(Process.GetProcessesByName("antigravity"));
+			processes.AddRange(Process.GetProcessesByName("Antigravity"));
 #else
-			processes.AddRange(Process.GetProcessesByName("cursor"));
+			processes.AddRange(Process.GetProcessesByName("antigravity"));
 #endif
 
 			foreach (var process in processes)
@@ -559,7 +559,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 				}
 				catch (Exception ex)
 				{
-					Debug.LogError($"[Cursor] Error checking process: {ex}");
+					Debug.LogError($"[Antigravity] Error checking process: {ex}");
 					continue;
 				}
 			}
@@ -589,7 +589,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 
 			if (EditorPrefs.GetBool(ReuseExistingWindowKey, false))
 			{
-				var existingProcess = FindRunningCursorWithSolution(directory);
+				var existingProcess = FindRunningAntigravityWithSolution(directory);
 				if (existingProcess != null)
 				{
 					try
@@ -603,7 +603,7 @@ namespace Microsoft.Unity.VisualStudio.Editor
 					}
 					catch (Exception ex)
 					{
-						Debug.LogError($"[Cursor] Error using existing instance: {ex}");
+						Debug.LogError($"[Antigravity] Error using existing instance: {ex}");
 					}
 				}
 			}

--- a/Editor/VisualStudioEditor.cs
+++ b/Editor/VisualStudioEditor.cs
@@ -132,13 +132,13 @@ namespace Microsoft.Unity.VisualStudio.Editor
 			GUILayout.Label($"<size=10><color=grey>{package.displayName} v{package.version} enabled</color></size>", style);
 			GUILayout.EndHorizontal();
 
-			if (installation is VisualStudioCursorInstallation)
+			if (installation is VisualStudioAntigravityInstallation)
 			{
-				var reuseWindow = EditorPrefs.GetBool(VisualStudioCursorInstallation.ReuseExistingWindowKey, false);
-				var newReuseWindow = EditorGUILayout.Toggle(new GUIContent("Reuse existing Cursor window", "When enabled, opens files in an existing Cursor window if found. When disabled, always opens a new window."), reuseWindow);
+				var reuseWindow = EditorPrefs.GetBool(VisualStudioAntigravityInstallation.ReuseExistingWindowKey, false);
+				var newReuseWindow = EditorGUILayout.Toggle(new GUIContent("Reuse existing Antigravity window", "When enabled, opens files in an existing Antigravity window if found. When disabled, always opens a new window."), reuseWindow);
 				if (newReuseWindow != reuseWindow)
-					EditorPrefs.SetBool(VisualStudioCursorInstallation.ReuseExistingWindowKey, newReuseWindow);
-				
+					EditorPrefs.SetBool(VisualStudioAntigravityInstallation.ReuseExistingWindowKey, newReuseWindow);
+
 				EditorGUILayout.Space();
 			}
 

--- a/Editor/com.unity.ide.visualstudio.asmdef
+++ b/Editor/com.unity.ide.visualstudio.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Unity.Cursor.Editor",
+    "name": "Unity.Antigravity.Editor",
     "references": [],
     "includePlatforms": [
         "Editor"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 - Unity -> Window -> Package Manager  
 - Click "+" at the top left corner  
 - Add package from git URL  
-- Insert `https://github.com/boxqkrtm/com.unity.ide.cursor.git`  
+- Insert `https://github.com/boxqkrtm/com.unity.ide.antigravity.git`  
 - Add  
 - Done
 
-> **Important Notice for Users Updating from Older Versions**  
-> Starting from version **v2.0.24**, the package name has been changed from  
-> `com.unity.ide.cursor` to `com.boxqkrtm.ide.cursor` to prevent potential issues with Unity regarding attribution.  
+> **Important Notice for Users Updating from Older Versions**
+> Starting from version **v2.0.24**, the package name has been changed from
+> `com.unity.ide.antigravity` to `com.boxqkrtm.ide.antigravity` to prevent potential issues with Unity regarding attribution.  
 > Violating these attribution rules may trigger warnings in Unity.  
 > If you experience errors during the update, please remove the existing package before reinstalling the new one to avoid conflicts.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "com.boxqkrtm.ide.cursor",
-  "displayName": "Cursor Editor",
-  "description": "Cursor editor integration for supporting Cursor as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
+  "name": "com.boxqkrtm.ide.antigravity",
+  "displayName": "Antigravity Editor",
+  "description": "Antigravity editor integration for supporting Antigravity as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
   "version": "2.0.27",
   "unity": "2019.4",
   "unityRelease": "25f1",
@@ -9,6 +9,6 @@
     "com.unity.test-framework": "1.1.9"
   },
   "_upm": {
-    "changelog": "Integration:\n\n- Add Multiple or Single Cursor Instance Options"
+    "changelog": "Integration:\n\n- Add Multiple or Single Antigravity Instance Options"
   }
 }


### PR DESCRIPTION
This commit transforms the Unity IDE integration package from Cursor to Antigravity:

Changes:
- Renamed package from com.boxqkrtm.ide.cursor to com.boxqkrtm.ide.antigravity
- Updated display name from "Cursor Editor" to "Antigravity Editor"
- Renamed VisualStudioCursorInstallation to VisualStudioAntigravityInstallation
- Updated all installation paths and process names
  - Windows: cursor/cursor.exe → antigravity/antigravity.exe
  - macOS: Cursor*.app → Antigravity*.app
  - Linux: /usr/bin/cursor → /usr/bin/antigravity
- Updated workspace storage paths
  - macOS: cursor/User → antigravity/User
  - Linux: Cursor/User → Antigravity/User
  - Windows: cursor/User → antigravity/User
- Changed EditorPrefs key: cursor_reuse_existing_window → antigravity_reuse_existing_window
- Updated UI labels and debug messages
- Modified assembly name: Unity.Cursor.Editor → Unity.Antigravity.Editor
- Updated documentation and changelog

All functional behavior remains the same, only the editor name and paths have changed.